### PR TITLE
update hyperdb and use real deletion

### DIFF
--- a/index.js
+++ b/index.js
@@ -269,7 +269,7 @@ Graph.prototype._generateBatch = function (triple, action) {
     data = JSON.stringify(utils.extraDataMask(triple))
   }
   return this._encodeKeys(triple).map(key => ({
-    type: 'put', // no delete in hyperdb so just putting nulls
+    type: action,
     key: key,
     value: data
   }))

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,25 +47,18 @@
       }
     },
     "buffer-alloc": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.1.0.tgz",
-      "integrity": "sha1-BVFNM78WVtNUDGhPZbEgLpDsowM=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
       "requires": {
-        "buffer-alloc-unsafe": "0.1.1",
-        "buffer-fill": "0.1.1"
-      },
-      "dependencies": {
-        "buffer-alloc-unsafe": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-0.1.1.tgz",
-          "integrity": "sha1-/+H2dVHdBVc33iUzN7/oU9+rGmo="
-        }
+        "buffer-alloc-unsafe": "1.1.0",
+        "buffer-fill": "1.0.0"
       }
     },
     "buffer-alloc-unsafe": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.0.0.tgz",
-      "integrity": "sha1-R0qojzTnvHX6MR0uZFdAnFhGw/4="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
     },
     "buffer-equals": {
       "version": "1.0.4",
@@ -73,9 +66,9 @@
       "integrity": "sha1-A1O1T9B/2VZBcGca5vZrnPENJ/U="
     },
     "buffer-fill": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-0.1.1.tgz",
-      "integrity": "sha512-YgBMBzdRLEfgxJIGu2wrvI2E03tMCFU1p7d1KhB4BOoMN0VxmTFjSyN5JtKt9z8Z9JajMHruI6SE25W96wNv7Q=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
     },
     "buffer-from": {
       "version": "1.0.0",
@@ -661,25 +654,28 @@
       }
     },
     "hypercore": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/hypercore/-/hypercore-6.14.0.tgz",
-      "integrity": "sha512-cM7IqW37u7JmG79yeaoaFuCMz7IEk+v/aQsnWrYo0HHTubRs36R28PoKVQykb9jcF7F7g6GT+yxTO+yG/hwe6Q==",
+      "version": "6.18.1",
+      "resolved": "https://registry.npmjs.org/hypercore/-/hypercore-6.18.1.tgz",
+      "integrity": "sha512-pH2t3ehdTfe/FFrwVq+6w7L9NoWEnFO9Yxix2kj43vSLMHTWCUFdOCJ9/MaOUAG4OeYy4tiT4+IE5NP0bff6Mg==",
       "requires": {
         "array-lru": "1.1.1",
         "atomic-batcher": "1.0.2",
         "bitfield-rle": "2.1.0",
-        "buffer-alloc-unsafe": "1.0.0",
+        "buffer-alloc-unsafe": "1.1.0",
         "buffer-equals": "1.0.4",
         "buffer-from": "1.0.0",
         "bulk-write-stream": "1.1.4",
         "codecs": "1.2.1",
         "flat-tree": "1.6.0",
         "from2": "2.3.0",
+        "hypercore-crypto": "1.0.0",
         "hypercore-protocol": "6.6.4",
         "inherits": "2.0.3",
+        "inspect-custom-symbol": "1.1.0",
         "last-one-wins": "1.0.4",
         "memory-pager": "1.1.0",
         "merkle-tree-stream": "3.0.3",
+        "pretty-hash": "1.0.1",
         "process-nextick-args": "1.0.7",
         "random-access-file": "2.0.1",
         "sodium-universal": "2.0.0",
@@ -687,7 +683,25 @@
         "thunky": "1.0.2",
         "uint64be": "2.0.2",
         "unordered-array-remove": "1.0.2",
-        "unordered-set": "2.0.0"
+        "unordered-set": "2.0.1"
+      }
+    },
+    "hypercore-crypto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hypercore-crypto/-/hypercore-crypto-1.0.0.tgz",
+      "integrity": "sha512-xFwOnNlOt8L+SovC7dTNchKaNYJb5l8rKZZwpWQnCme1r7CU4Hlhp1RDqPES6b0OpS7DkTo9iU0GltQGkpsjMw==",
+      "requires": {
+        "buffer-alloc-unsafe": "1.1.0",
+        "buffer-from": "1.1.1",
+        "sodium-universal": "2.0.0",
+        "uint64be": "2.0.2"
+      },
+      "dependencies": {
+        "buffer-from": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+          "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+        }
       }
     },
     "hypercore-protocol": {
@@ -695,7 +709,7 @@
       "resolved": "https://registry.npmjs.org/hypercore-protocol/-/hypercore-protocol-6.6.4.tgz",
       "integrity": "sha512-9TU7P+uve0e5v1ZiBx70DFhkpepW4iNSGYlZthK+Unm0EbZ+Yppc6clH7JTffPBNUMSnDrE552MfXMilpCHZMw==",
       "requires": {
-        "buffer-alloc-unsafe": "1.0.0",
+        "buffer-alloc-unsafe": "1.1.0",
         "buffer-from": "1.0.0",
         "inherits": "2.0.3",
         "protocol-buffers-encodings": "1.1.0",
@@ -706,15 +720,15 @@
       }
     },
     "hyperdb": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/hyperdb/-/hyperdb-3.1.0.tgz",
-      "integrity": "sha512-Eev4CwAx8+MzD1AmQxDfGz7kN2McA+cX5pkZx/kNgBHPct7mrDIWm0XyYhAsUCvV1sANu886/f9vJC1JxvhCfw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/hyperdb/-/hyperdb-3.4.0.tgz",
+      "integrity": "sha512-72Kf1BBwxJKO88+JyhqppLo1INibMRhqz2XJ2Vwy2IMkPdoaGiY4VHoVRDkWCdRlBSiZAJHy/ElQAbHM8Bq4aQ==",
       "requires": {
         "array-lru": "1.1.1",
         "bulk-write-stream": "1.1.4",
         "codecs": "1.2.1",
         "compare": "2.0.0",
-        "hypercore": "6.14.0",
+        "hypercore": "6.18.1",
         "hypercore-protocol": "6.6.4",
         "inherits": "2.0.3",
         "mutexify": "1.2.0",
@@ -724,7 +738,7 @@
         "sodium-universal": "2.0.0",
         "thunky": "1.0.2",
         "unordered-array-remove": "1.0.2",
-        "unordered-set": "2.0.0",
+        "unordered-set": "2.0.1",
         "varint": "5.0.0"
       }
     },
@@ -738,6 +752,11 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "optional": true
+    },
+    "inspect-custom-symbol": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/inspect-custom-symbol/-/inspect-custom-symbol-1.1.0.tgz",
+      "integrity": "sha512-vtI2YXBRZBkU6DlfHfd0GtZENfiEiTacAXUd0ZY6HA+X7aPznpFfPmzSC+tHKXAkz9KDSdI4AYfwAMXR5t+isg=="
     },
     "istanbul": {
       "version": "0.4.5",
@@ -1341,7 +1360,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -1368,7 +1387,7 @@
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -1455,7 +1474,7 @@
         "supports-color": {
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "integrity": "sha1-iD992rwWUUKyphQn8zUt7RldGj4=",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -1501,10 +1520,15 @@
       }
     },
     "node-gyp-build": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.3.0.tgz",
-      "integrity": "sha512-SNtBzznpPggc7mY8XTfnYBywd9OGN99bwnxGKFqud9erYJMbwnJn6B8HXER2dy8iOYr6Nf2SzBQoJjV8gdM4Nw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.4.0.tgz",
+      "integrity": "sha512-YoviGBJYGrPdLOKDIQB0sKxuKy/EEsxzooNkOZak4vSTKT/qH0Pa6dj3t1MJjEQGsefih61IyHDmO1WW7xOFfw==",
       "optional": true
+    },
+    "pretty-hash": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pretty-hash/-/pretty-hash-1.0.1.tgz",
+      "integrity": "sha1-FuBXkYje9WvbVliSvNBaXWUySAc="
     },
     "process-nextick-args": {
       "version": "1.0.7",
@@ -1558,7 +1582,7 @@
       "integrity": "sha512-nb4fClpzoUY+v1SHrro+9yykN90eMA1rc+xM39tnZ5R3BgFY+J/NxPZ0KuUpishEsvnwou9Fvm2wa3cjeuG7vg==",
       "requires": {
         "mkdirp": "0.5.1",
-        "random-access-storage": "1.2.0"
+        "random-access-storage": "1.3.0"
       }
     },
     "random-access-memory": {
@@ -1579,9 +1603,9 @@
       }
     },
     "random-access-storage": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/random-access-storage/-/random-access-storage-1.2.0.tgz",
-      "integrity": "sha512-KASq0p0d4Tri71p1w9+gvKBhUpjt9/9TGtVMschfwNjdw93rZFnKlsZ+4CKFq/qi2GvdobIFLu0CjnQpfsr05Q==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/random-access-storage/-/random-access-storage-1.3.0.tgz",
+      "integrity": "sha512-pdS9Mcb9TB7oICypPRALlheaSuszuAKmLVEPKJMuYor7R/zDuHh5ALuQoS+ox31XRwQUL+tDwWH2GPdyspwelA==",
       "requires": {
         "inherits": "2.0.3"
       }
@@ -1644,9 +1668,9 @@
       }
     },
     "siphash24": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/siphash24/-/siphash24-1.1.0.tgz",
-      "integrity": "sha512-nDCEEZKb6m7OxxG/5wwaLy2R+KpyLcOnGjTJlFXG+14FUmpDD1FCFV/MjsYATjShsqPkSkl1BVevI0TCehdsTw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/siphash24/-/siphash24-1.1.1.tgz",
+      "integrity": "sha512-dKKwjIoTOa587TARYLlBRXq2lkbu5Iz35XrEVWpelhBP1m8r2BGOy1QlaZe84GTFHG/BTucEUd2btnNc8QzIVA==",
       "requires": {
         "nanoassert": "1.1.0"
       }
@@ -1658,19 +1682,19 @@
       "requires": {
         "blake2b": "2.1.2",
         "nanoassert": "1.1.0",
-        "siphash24": "1.1.0",
+        "siphash24": "1.1.1",
         "xsalsa20": "1.0.2"
       }
     },
     "sodium-native": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-2.1.6.tgz",
-      "integrity": "sha512-vfovcNlU8C93SbeNoGSAdW5zVOTlrh1sTy+TzdC2FhDTE/IUK6j4ML5gdr/qziLz4XRT4EQWJvbFzql6CAAH/A==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-2.2.1.tgz",
+      "integrity": "sha512-3CfftYV2ATXQFMIkLOvcNUk/Ma+lran0855j5Z/HEjUkSTzjLZi16CK362udOoNVrwn/TwGV8bKEt5OylsFrQA==",
       "optional": true,
       "requires": {
         "ini": "1.3.5",
         "nan": "2.10.0",
-        "node-gyp-build": "3.3.0"
+        "node-gyp-build": "3.4.0"
       }
     },
     "sodium-universal": {
@@ -1679,7 +1703,7 @@
       "integrity": "sha512-csdVyakzHJRyCevY4aZC2Eacda8paf+4nmRGF2N7KxCLKY2Ajn72JsExaQlJQ2BiXJncp44p3T+b80cU+2TTsg==",
       "requires": {
         "sodium-javascript": "0.5.5",
-        "sodium-native": "2.1.6"
+        "sodium-native": "2.2.1"
       }
     },
     "sorted-indexof": {
@@ -3581,7 +3605,7 @@
       "resolved": "https://registry.npmjs.org/uint64be/-/uint64be-2.0.2.tgz",
       "integrity": "sha512-9QqdvpGQTXgxthP+lY4e/gIBy+RuqcBaC6JVwT5I3bDLgT/btL6twZMR0pI3/Fgah9G/pdwzIprE5gL6v9UvyQ==",
       "requires": {
-        "buffer-alloc": "1.1.0"
+        "buffer-alloc": "1.2.0"
       }
     },
     "unordered-array-remove": {
@@ -3590,9 +3614,9 @@
       "integrity": "sha1-xUbo+I4xegzyZEyX7LV9umbSUO8="
     },
     "unordered-set": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unordered-set/-/unordered-set-2.0.0.tgz",
-      "integrity": "sha1-mFon6XW6oguCY66np5HpMAlBqew="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unordered-set/-/unordered-set-2.0.1.tgz",
+      "integrity": "sha512-eUmNTPzdx+q/WvOHW0bgGYLWvWHNT3PTKEQLg0MAQhc0AHASHVHoP/9YytYd4RBVariqno/mEUhVZN98CmD7bg=="
     },
     "varint": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/e-e-e/hyper-graph-db/issues"
   },
   "dependencies": {
-    "hyperdb": "^3.1.0",
+    "hyperdb": "^3.4.0",
     "inherits": "^2.0.3",
     "lru": "^3.1.0",
     "pump": "^3.0.0",

--- a/test/triple-store.spec.js
+++ b/test/triple-store.spec.js
@@ -628,7 +628,7 @@ describe('generateBatch', function () {
       var ops = db._generateBatch(triple, 'del')
       expect(ops).to.have.property('length', 6)
       ops.forEach(function (op) {
-        expect(op).to.have.property('type', 'put')
+        expect(op).to.have.property('type', 'del')
         expect(JSON.parse(op.value)).to.eql(null)
       })
     })
@@ -656,7 +656,7 @@ describe('generateBatch', function () {
       var ops = db._generateBatch(triple, 'del')
       expect(ops).to.have.property('length', 3)
       ops.forEach(function (op) {
-        expect(op).to.have.property('type', 'put')
+        expect(op).to.have.property('type', 'del')
         expect(JSON.parse(op.value)).to.eql(null)
       })
     })


### PR DESCRIPTION
hyperdb implemented node deletion, but hyper-graph-db is still using setting null as deletion.
This PR fixes that. 