### PR TITLE
stop unnecessarily storing data in the value of db

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -124,9 +124,8 @@ function keyIsAVariable (tripleKey) {
 
 function extraDataMask (obj) {
   return Object.keys(obj)
-    .filter(not(keyIsAVariable))
     .reduce((prev, key) => {
-      prev[key] = obj[key]
+      if(!keyIsAVariable(obj[key]) && !hasKey(key)) prev[key] = obj[key]
       return prev
     }, {})
 }

--- a/test/triple-store.spec.js
+++ b/test/triple-store.spec.js
@@ -614,12 +614,12 @@ describe('generateBatch', function () {
       db.close(done)
     })
     it('should generate a batch from a triple with length 6', function () {
-      var triple = { subject: 'a', predicate: 'b', object: 'c' }
+      var triple = { subject: 'a', predicate: 'b', object: 'c', extra: 'data' }
       var ops = db._generateBatch(triple)
       expect(ops).to.have.property('length', 6)
       ops.forEach(function (op) {
         expect(op).to.have.property('type', 'put')
-        expect(JSON.parse(op.value)).to.eql(triple)
+        expect(JSON.parse(op.value)).to.eql({ extra: 'data' })
       })
     })
 
@@ -642,17 +642,17 @@ describe('generateBatch', function () {
       db.close(done)
     })
     it('should generate a batch from a triple with length 3', function () {
-      var triple = { subject: 'a', predicate: 'b', object: 'c' }
+      var triple = { subject: 'a', predicate: 'b', object: 'c', other: 'stuff' }
       var ops = db._generateBatch(triple)
       expect(ops).to.have.property('length', 3)
       ops.forEach(function (op) {
         expect(op).to.have.property('type', 'put')
-        expect(JSON.parse(op.value)).to.eql(triple)
+        expect(JSON.parse(op.value)).to.eql({ other: 'stuff' })
       })
     })
 
     it('should generate a batch of type', function () {
-      var triple = { subject: 'a', predicate: 'b', object: 'c' }
+      var triple = { subject: 'a', predicate: 'b', object: 'c', other: 'stuff' }
       var ops = db._generateBatch(triple, 'del')
       expect(ops).to.have.property('length', 3)
       ops.forEach(function (op) {


### PR DESCRIPTION
This PR removes subject predicate and object from the value in hyperdb. This is because all this information is already derived from the index key anyway. At the moment this arbitrarily increases the storage size of a db.